### PR TITLE
Reestructuracion del menu principal

### DIFF
--- a/custom_components/accurate_solar_forecast/config_flow.py
+++ b/custom_components/accurate_solar_forecast/config_flow.py
@@ -84,10 +84,10 @@ class AccurateForecastFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         schema = vol.Schema({
             vol.Required("name"): str,
-            vol.Required(CONF_REF_SENSOR): selector.EntitySelector(
+            vol.Required("irradiance_sensor"): selector.EntitySelector(
                 selector.EntitySelectorConfig(
                     domain="sensor", 
-                    device_class=["irradiance", "power"]
+                    device_class="irradiance"
                 )
             ),
             vol.Optional(CONF_TEMP_SENSOR): selector.EntitySelector(

--- a/custom_components/accurate_solar_forecast/translations/en.json
+++ b/custom_components/accurate_solar_forecast/translations/en.json
@@ -30,7 +30,7 @@
                 "description": "Configure an existing irradiance sensor.",
                 "data": {
                     "name": "Name",
-                    "ref_sensor": "Irradiance Sensor",
+                    "irradiance_sensor": "Irradiance Sensor",
                     "temp_sensor": "Temperature Sensor",
                     "wind_sensor": "Wind Speed Sensor"
                 }

--- a/custom_components/accurate_solar_forecast/translations/es.json
+++ b/custom_components/accurate_solar_forecast/translations/es.json
@@ -30,7 +30,7 @@
                 "description": "Configura un sensor de irradiancia existente.",
                 "data": {
                     "name": "Nombre",
-                    "ref_sensor": "Sensor de Irradiancia",
+                    "irradiance_sensor": "Sensor de Irradiancia",
                     "temp_sensor": "Sensor de Temperatura",
                     "wind_sensor": "Sensor de Viento"
                 }


### PR DESCRIPTION
Se ha reestructurado el menú principal del flujo de configuración para incluir tres opciones claras: añadir modelo fotovoltaico, añadir sensor de irradiancia y crear nuevo forecast de string. Específicamente, se ha implementado la lógica para añadir un sensor de irradiancia, asegurando que el selector de entidad filtre exclusivamente sensores con device_class="irradiance" (W/m²), y se han actualizado los archivos de traducción (español e inglés) para reflejar correctamente los nombres y descripciones en la interfaz de usuario..